### PR TITLE
fix error in catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,1 +1,12 @@
-Audiences in Jwt are not allowed
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "Geonorge.Kartkatalog"
+  tags:
+  - "public"
+spec:
+  type: "website"
+  lifecycle: "production"
+  owner: "datadeling_og_distribusjon"
+  system: "geonorge"


### PR DESCRIPTION
Backstage was not able to read the catalog-info from this file. With this fix, it should be OK again